### PR TITLE
fix rspec + cucumber tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ group :test do
   gem 'rspec'
   gem 'cucumber'
   gem 'aruba'
-  gem 'ci_reporter'
+  gem 'ci_reporter_rspec', '~> 1.0'
   gem 'rspec-its'
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ group :test do
   gem 'cucumber'
   gem 'aruba'
   gem 'ci_reporter'
+  gem 'rspec-its'
 end
 
 group :development do

--- a/Gemfile
+++ b/Gemfile
@@ -14,12 +14,4 @@ end
 group :development do
   gem 'rake'
   gem 'pry'
-
-  gem 'vagrant', :github => 'mitchellh/vagrant',
-                 :ref => 'v1.5.1',
-                 :platform => :mri
-end
-
-group :plugins do
-  gem 'vagrant-aws', :platform => :mri
 end

--- a/Gemfile
+++ b/Gemfile
@@ -14,8 +14,6 @@ end
 group :development do
   gem 'rake'
   gem 'pry'
-  gem 'debugger', :platform => :mri
-  gem 'debugger-pry', :platform => :mri
 
   gem 'vagrant', :github => 'mitchellh/vagrant',
                  :ref => 'v1.5.1',

--- a/features/step_definitions/catalog_steps.rb
+++ b/features/step_definitions/catalog_steps.rb
@@ -1,15 +1,16 @@
 Given(/^I have catalog meta\-data$/) do
-  JPM.stub(:repository_path).and_return(
-    File.expand_path(File.dirname(__FILE__) + '/../../spec/fixtures/update-center.json'))
+  allow(JPM).to receive(:repository_path) do
+    File.expand_path(File.dirname(__FILE__) + '/../../spec/fixtures/update-center.json')
+  end
 end
 
 Given(/^an update\-center\.json doesn't already exist$/) do
   # Found in Aruba::Api
-  in_current_dir do
+  cd('.') do
 
     # Relative path, since our Dir.pwd will be tmp/aruba already
     repo = './update-center.json'
-    JPM.stub(:repository_path).and_return(repo)
+    allow(JPM).to receive(:repository_path) { repo }
 
     # If the thing exists already, nuke it!
     if File.exists? repo
@@ -20,11 +21,11 @@ end
 
 Given(/^an update\-center\.json already exists$/) do
   # Found in Aruba::Api
-  in_current_dir do
+  cd('.') do
 
     # Relative path, since our Dir.pwd will be tmp/aruba already
     repo = './update-center.json'
-    JPM.stub(:repository_path).and_return(repo)
+    allow(JPM).to receive(:repository_path) { repo }
     File.open(repo, 'w+') do |fd|
       fd.write("\n{}\n")
     end
@@ -34,7 +35,7 @@ end
 Given(/^I have a site with a custom update\-center\.json$/) do
   # Relative path, since our Dir.pwd will be tmp/aruba already
   repo = './update-center.json'
-  JPM.stub(:repository_path).and_return(repo)
+  allow(JPM).to receive(:repository_path) { repo }
 
   # If the thing exists already, nuke it!
   if File.exists? repo
@@ -43,6 +44,6 @@ Given(/^I have a site with a custom update\-center\.json$/) do
 
   response = double('Mock HTTPResponse', :body => '')
 
-  JPM.should_receive(:fetch).with('http://aruba.bdd/update-center.json').and_return(response)
+  expect(JPM).to receive(:fetch).with('http://aruba.bdd/update-center.json') { response }
 end
 

--- a/features/step_definitions/general_steps.rb
+++ b/features/step_definitions/general_steps.rb
@@ -1,25 +1,27 @@
 Given(/^Jenkins isn't installed$/) do
-  JPM.stub(:installed? => false)
+  allow(JPM).to receive(:installed?) { false }
 end
 
 Given(/^Jenkins is installed$/) do
-  JPM.stub(:installed? => true)
+  allow(JPM).to receive(:installed?) { false }
 end
 
 Given(/^there are no plugins available$/) do
-  JPM.stub(:plugins => [])
+  allow(JPM).to receive(:plugins) { [] }
 end
 
 Given(/^there are plugins available$/) do
-  JPM.stub(:has_plugins? => true)
-  JPM.stub(:plugins => [
-    {
-      :name => 'greenballs',
-      :version => '1.0'
-    },
-    {
-     :name => 'ant',
-     :version => '1.1'
-    },
-  ])
+  allow(JPM).to receive(:has_plugins?) { true }
+  allow(JPM).to receive(:plugins) do
+    [
+      {
+        :name => 'greenballs',
+        :version => '1.0'
+      },
+      {
+       :name => 'ant',
+       :version => '1.1'
+      },
+    ]
+  end
 end

--- a/features/support/aruba.rb
+++ b/features/support/aruba.rb
@@ -54,5 +54,7 @@ module JPM
   end
 end
 
-Aruba::InProcess.main_class = JPM::Cucumber::CLIRunner
-Aruba.process = Aruba::InProcess
+Aruba.configure do |config|
+  config.command_launcher = :in_process
+  config.main_class = JPM::Cucumber::CLIRunner
+end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -1,10 +1,5 @@
 require 'rubygems'
 require 'cucumber/rspec/doubles'
+require 'pry'
 
 require 'jpm/cli'
-
-unless RUBY_PLATFORM == 'java'
-  require 'debugger'
-  require 'debugger/pry'
-end
-

--- a/features/support/install.rb
+++ b/features/support/install.rb
@@ -1,4 +1,4 @@
 
 Before '@install-success' do
-  JPM::Catalog.any_instance.stub(:download).and_return(true)
+  expect(JPM::Catalog).to receive(:download) { true }
 end

--- a/spec/catalog_spec.rb
+++ b/spec/catalog_spec.rb
@@ -47,13 +47,13 @@ describe JPM::Catalog do
 
     context 'with an empty or nil argument' do
       let(:plugins) { [] }
-      it { should be_empty }
+      it { is_expected.to be_empty }
     end
 
     context 'with a plugin which has no dependencies' do
       let(:plugins) { ['greenballs'] }
 
-      it { should_not be_empty }
+      it { is_expected.not_to be_empty }
       its(:size) { should eql 1 }
 
       it 'should have an instance of JPM::Plugin<greenballs>' do
@@ -67,7 +67,7 @@ describe JPM::Catalog do
       # Depends on `credentials`
       let(:plugins) { ['ssh-credentials'] }
 
-      it { should_not be_empty }
+      it { is_expected.not_to be_empty }
       its(:size) { should eql 2 }
 
       it 'should have the right JPM::Plugins computed' do
@@ -81,7 +81,7 @@ describe JPM::Catalog do
       # Depends on ssh-credentials -> credentials
       let(:plugins) { ['git-client'] }
 
-      it { should_not be_empty }
+      it { is_expected.not_to be_empty }
       its(:size) { should eql 3 }
     end
   end
@@ -100,8 +100,8 @@ describe JPM::Catalog do
       response = double('Mock HTTPResponse',
                         :body => '',
                         :code => 200)
-      JPM.should_receive(:fetch).with(plugin.url).and_return(response)
-      catalog.should_receive(:save_plugin).and_return(true)
+      expect(JPM).to receive(:fetch).with(plugin.url).and_return(response)
+      expect(catalog).to receive(:save_plugin).and_return(true)
 
       expect(installation).to be_true
     end
@@ -113,7 +113,7 @@ describe JPM::Catalog do
     context 'with a valid fixtured update-center.json' do
       let(:fixture) { File.expand_path(File.dirname(__FILE__) + '/fixtures/update-center.json') }
 
-      it { should be_instance_of described_class }
+      it { is_expected.to be_instance_of described_class }
       # Our fixture file currently has 870 plugins in it
       its(:size) { should eql 870 }
     end

--- a/spec/catalog_spec.rb
+++ b/spec/catalog_spec.rb
@@ -103,7 +103,7 @@ describe JPM::Catalog do
       expect(JPM).to receive(:fetch).with(plugin.url).and_return(response)
       expect(catalog).to receive(:save_plugin).and_return(true)
 
-      expect(installation).to be_true
+      expect(installation).to be true
     end
   end
 

--- a/spec/dependency_spec.rb
+++ b/spec/dependency_spec.rb
@@ -10,8 +10,8 @@ describe JPM::Dependency do
         {"name"=>"ssh-credentials", "optional"=>false, "version"=>"1.5.1"}
       end
 
-      it { should be_instance_of described_class }
-      it { should_not be_optional }
+      it { is_expected.to be_instance_of described_class }
+      it { is_expected.not_to be_optional }
       its(:name) { should eql 'ssh-credentials' }
       its(:min_version) { should eql '1.5.1' }
     end

--- a/spec/jpm_spec.rb
+++ b/spec/jpm_spec.rb
@@ -5,17 +5,17 @@ describe JPM do
   describe '.installed?' do
     subject { described_class.installed? }
     before :each do
-      described_class.should_receive(:home_dir).and_return(home_dir)
+      expect(described_class).to receive(:home_dir).and_return(home_dir)
     end
 
     context 'without Jenkins' do
       let(:home_dir) { nil }
-      it { should be_false }
+      it { is_expected.to be_falsey }
     end
 
     context 'with Jenkins' do
       let(:home_dir) { '/var/lib/jenkins' }
-      it { should be_true }
+      it { is_expected.to be_truthy }
     end
   end
 
@@ -24,35 +24,35 @@ describe JPM do
 
     context "when a jenkins user doesn't exist" do
       before :each do
-        File.should_receive(:expand_path).and_raise(ArgumentError)
+        expect(File).to receive(:expand_path).and_raise(ArgumentError)
       end
 
-      it { should be_nil }
+      it { is_expected.to be_nil }
     end
 
     context 'when a jenkins user does exist' do
       let(:home) { '/rspec/jenkins' }
 
       before :each do
-        File.should_receive(:expand_path).and_return(home)
+        expect(File).to receive(:expand_path).and_return(home)
       end
 
-      it { should eql home }
+      it { is_expected.to eql home }
     end
   end
 
   describe '.has_plugins?' do
     subject(:exists) { described_class.has_plugins? }
     before :each do
-      JPM.stub(:plugins_dir).and_call_original
+      allow(JPM).to receive(:plugins_dir).and_call_original
     end
 
     context 'if jenkins does not exist' do
       before :each do
-        JPM.stub(:home_dir).and_return(nil)
+        allow(JPM).to receive(:home_dir).and_return(nil)
       end
 
-      it { should be false }
+      it { is_expected.to be false }
     end
 
     context 'if jenkins exists' do
@@ -60,29 +60,29 @@ describe JPM do
       let(:dir_exists) { false }
 
       before :each do
-        JPM.stub(:home_dir).and_return(home)
-        File.should_receive(:directory?).with(File.join(home, 'plugins')).and_return(dir_exists)
+        allow(JPM).to receive(:home_dir).and_return(home)
+        expect(File).to receive(:directory?).with(File.join(home, 'plugins')).and_return(dir_exists)
       end
 
       context 'and the directory exists' do
         let(:dir_exists) { true }
         before :each do
-          Dir.should_receive(:entries).and_return(entries)
+          expect(Dir).to receive(:entries).and_return(entries)
         end
 
         context 'but is empty' do
           let(:entries) { ['.', '..'] }
-          it { should be false }
+          it { is_expected.to be false }
         end
 
         context 'and has plugins' do
           let(:entries) { ['.', '..', 'ant'] }
-          it { should be true }
+          it { is_expected.to be true }
         end
       end
 
       context 'and the directory does not exist' do
-        it { should be false }
+        it { is_expected.to be false }
       end
     end
   end
@@ -92,11 +92,11 @@ describe JPM do
 
     context 'when plugins do not exist' do
       before :each do
-        described_class.should_receive(:has_plugins?).and_return(false)
+        expect(described_class).to receive(:has_plugins?).and_return(false)
       end
 
-      it { should be_empty }
-      it { should be_instance_of Array }
+      it { is_expected.to be_empty }
+      it { is_expected.to be_instance_of Array }
     end
 
     context 'when plugins exist' do

--- a/spec/jpm_spec.rb
+++ b/spec/jpm_spec.rb
@@ -10,7 +10,7 @@ describe JPM do
 
     context 'without Jenkins' do
       let(:home_dir) { nil }
-      it { is_expected.to be_falsey }
+      it { is_expected.to be false }
     end
 
     context 'with Jenkins' do
@@ -102,6 +102,7 @@ describe JPM do
     context 'when plugins exist' do
       it 'should generate a list of plugins' do
         pending 'This is too hard to unit test, feh.'
+        raise
       end
     end
   end

--- a/spec/manifest_spec.rb
+++ b/spec/manifest_spec.rb
@@ -41,7 +41,7 @@ Plugin-Developers:
 '
       end
 
-      it { should be_kind_of Hash }
+      it { is_expected.to be_kind_of Hash }
 
       it 'should parse the right plugin version' do
         expect(data[:plugin_version]).to eql('1.2')
@@ -77,7 +77,7 @@ Plugin-Developers: Kohsuke Kawaguchi:kohsuke:,Nicolas De Loof:ndeloof:
 '
       end
 
-      it { should be_kind_of Hash }
+      it { is_expected.to be_kind_of Hash }
       it 'should have the right number of keys' do
         expect(data.keys.size).to eql(18)
       end

--- a/spec/plugin_spec.rb
+++ b/spec/plugin_spec.rb
@@ -95,13 +95,13 @@ describe JPM::Plugin do
     let(:plugin) { described_class.from_hash(data) }
     subject(:shortform) { plugin.shortform }
 
-    it { should be_instance_of String }
+    it { is_expected.to be_instance_of String }
 
     context 'with no labels' do
       before :each do
         data['labels'] = nil
       end
-      it { should be_instance_of String }
+      it { is_expected.to be_instance_of String }
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,11 +1,6 @@
 require 'rubygems'
 require 'rspec'
 require 'rspec/its'
+require 'pry'
 
 $LOAD_PATH.unshift(File.expand_path(File.dirname(__FILE__) + '/../lib'))
-
-unless RUBY_PLATFORM == 'java'
-  require 'debugger'
-  require 'debugger/pry'
-end
-

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,6 @@
 require 'rubygems'
 require 'rspec'
+require 'rspec/its'
 
 $LOAD_PATH.unshift(File.expand_path(File.dirname(__FILE__) + '/../lib'))
 


### PR DESCRIPTION
Updates the rspec + cucumber syntax & configuration so that the default rake target will run with current gem versions.  Note: I have not tested the cucumber acceptance tests on a live Jenkins master -- additional changes may be necessary.
